### PR TITLE
change nextTop to only increment by 1 sibling

### DIFF
--- a/src/scripts/Scroller.js
+++ b/src/scripts/Scroller.js
@@ -9,7 +9,7 @@ export class Scroller {
         let nextTop = 0;
 
         try {
-          nextTop = this.nextSibling.nextSibling.getBoundingClientRect().top;
+          nextTop = this.nextSibling.getBoundingClientRect().top;
         } catch (e) {
           nextTop =
             this.scrollTop + this.clientHeight >= this.scrollHeight


### PR DESCRIPTION
In the minified version (and only the minified version), clicking the screen scrolls by two pages, not one. Very odd bug - not sure what's causing it. I removed one nextSibling property to restore normal scroll behavior.

The animation of the carat at the bottom still doesn't change when the page reaches the end, which is also strange. I have to do more debugging there, but it's out of scope for this PR.